### PR TITLE
Add export markers feature

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,6 +50,24 @@
       font-weight: 600;
       letter-spacing: 0.5px;
     }
+    #exportMarkersBtn {
+      position: absolute;
+      top: 60px;
+      left: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 16px;
+      padding: 10px 20px;
+      font-size: 16px;
+      font-family: inherit;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s, color 0.2s;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
     #addTreeBtn.adding {
       background: linear-gradient(90deg, #fdcb6e 60%, #ff6e44 100%);
       color: #222;
@@ -246,6 +264,7 @@
 <body>
   <h3 style="margin-left: 14px;">bee_tree</h3>
   <button id="addTreeBtn" title="Add a new annotation">+ Add Tree</button>
+  <button id="exportMarkersBtn" title="Download your markers">Export Markers</button>
   <div id="crosshair">
     <svg width="36" height="36">
       <circle cx="18" cy="18" r="13" stroke="#00b894" stroke-width="2.5" fill="none"/>

--- a/docs/user_markers.js
+++ b/docs/user_markers.js
@@ -15,6 +15,26 @@ function saveUserTrees() {
 
 window.userTrees = JSON.parse(localStorage.getItem('userTrees') || '[]');
 
+function exportUserMarkers() {
+  const data = window.userTrees.map(({type, lat, lng, notes, timestamp, id, name, showRadius, photoUrl}) => {
+    const obj = { type, lat, lng, notes, timestamp, id, name, showRadius };
+    if (photoUrl) obj.photoUrl = photoUrl;
+    return obj;
+  });
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const dateStr = new Date().toISOString().split('T')[0];
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `city_hive_user_markers_${dateStr}.json`;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 0);
+}
+
 // Remove all previous marker layers
 function clearUserMarkersFromMap() {
   if (window._userMarkerLayers) {
@@ -111,6 +131,8 @@ window.addingMode = false;
 var addTreeBtn = document.getElementById('addTreeBtn');
 var crosshair = document.getElementById('crosshair');
 var placeHereBtn = document.getElementById('placeHereBtn');
+var exportMarkersBtn = document.getElementById('exportMarkersBtn');
+if (exportMarkersBtn) exportMarkersBtn.onclick = exportUserMarkers;
 // Removed duplicate declaration of addTreeForm to fix JS error
 
 addTreeBtn.onclick = function() {


### PR DESCRIPTION
## Summary
- add Export Markers button and style
- implement exportUserMarkers in user_markers.js
- wire up button and function

## Testing
- `node -e "require('fs').readFileSync('docs/user_markers.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_683fabddd97c832d80b94867a7a394ed