### PR TITLE
Fix CH namespace initialization

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2,7 +2,7 @@
  * Application namespace used to avoid polluting the global scope.
  * Other scripts attach their exports to this object.
  */
-const CH = window.CityHive = window.CityHive || {};
+var CH = window.CityHive = window.CityHive || {};
 
 /**
  * Initialize the Leaflet map and muted basemap layer.

--- a/docs/markers.js
+++ b/docs/markers.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-const CH = window.CityHive = window.CityHive || {};
+var CH = window.CityHive;
 
 /**
  * Returns a color for the given tree species.

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -1,4 +1,4 @@
-const CH = window.CityHive = window.CityHive || {};
+var CH = window.CityHive;
 
 // Disable cluster click-to-zoom (uncluster only on zoom level)
 CH.markers.on('clusterclick', a => {

--- a/docs/user_markers.js
+++ b/docs/user_markers.js
@@ -1,5 +1,5 @@
 // --- User Marker Logic ---
-const CH = window.CityHive = window.CityHive || {};
+var CH = window.CityHive;
 
 /**
  * Return the pulse color for a given marker type.

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -1,4 +1,4 @@
 /**
  * Placeholder for shared utilities. Extend as needed.
  */
-const CH = window.CityHive = window.CityHive || {};
+var CH = window.CityHive;


### PR DESCRIPTION
## Summary
- use `var` for global `CH` namespace initialization
- reference the global object in other scripts without reassigning it

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbf02fbd8832da8064e3a59e95827