### PR TITLE
Update branding and map control styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ City_Hive is a lightweight mapping tool for beekeepers, researchers and land ste
 - **Import/Export** – download your markers as JSON and load them again on another device.
 - **Photo Uploads** – attach a photo (up to 5&nbsp;MB) to a marker. Images are stored in Firebase.
 - **Filtering** – show or hide markers by type (Hive, Swarm, Tree, Structure) via checkboxes.
-- **Mobile-Friendly Controls** – large buttons, a pop‑out legend and a "Locate me" tool for field use.
+- **Mobile-Friendly Controls** – gradient-styled buttons, a pop‑out legend and a "Locate me" tool for field use.
 - **Local Persistence** – all data is saved in `localStorage` so your notes remain even without a network connection.
 
 ## Installation

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -5,6 +5,7 @@
 - [x] Editable markers with notes and timestamps
 - [x] Mobile-friendly legend
 - [x] Basic mapping of NYC tree census data
+- [x] Branded map title and styled default controls
 
 ## In Progress
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>bee_tree</title>
+  <title>City_Hive</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
@@ -372,6 +372,28 @@
       height: 20px;
       margin-right: 4px;
     }
+    /* Style Leaflet zoom and locate controls */
+    .leaflet-control-zoom a,
+    .leaflet-bar.locate-btn {
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+      color: #fff;
+      border: none;
+      width: 44px;
+      height: 44px;
+      line-height: 44px;
+      font-size: 18px;
+      border-radius: 16px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s;
+    }
+    .leaflet-control-zoom a:hover,
+    .leaflet-bar.locate-btn:hover {
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+    }
+    .leaflet-control-zoom a:active,
+    .leaflet-bar.locate-btn:active {
+      transform: scale(0.95);
+    }
     @media (max-width: 600px) {
       #addSightingBtn { top: 130px; }
       #exportMarkersBtn { top: 190px; }
@@ -383,7 +405,7 @@
   </style>
 </head>
 <body>
-  <h3 style="margin-left: 14px;">bee_tree</h3>
+  <h3 style="margin-left: 14px;">City_Hive</h3>
   <button id="addSightingBtn" title="Add a new annotation">+ Add New Sighting</button>
   <button id="exportMarkersBtn" title="Download your markers">Export Markers</button>
   <button id="importMarkersBtn" title="Load markers from file">Import Markers</button>

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -39,12 +39,9 @@ document.addEventListener('keydown', e => {
 // Add a simple 'Locate Me' button
 const locateBtn = L.control({ position: 'topleft' });
 locateBtn.onAdd = map => {
-  const btn = L.DomUtil.create('button', 'leaflet-bar');
+  const btn = L.DomUtil.create('button', 'leaflet-bar locate-btn');
   btn.innerHTML = '📍';
   btn.title = 'Show My Location';
-  btn.style.background = '#fff';
-  btn.style.padding = '6px 10px';
-  btn.style.fontSize = '18px';
   btn.onclick = () => {
     map.locate({ setView: true, maxZoom: 17 });
   };


### PR DESCRIPTION
## Summary
- rebrand map title to **City_Hive**
- style default Leaflet zoom and locate controls with gradients and rounded corners
- add class for locate button and clean inline styles
- document the UI polish in README
- note milestone in Roadmap

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fc4097cc8832d8087ea7a40776182