### PR TITLE
Refresh project docs for City_Hive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@ This repository is often updated with the help of coding assistants. To keep con
 - There are no automated tests; manually load `docs/index.html` after changes to ensure the map still works.
 - When updating features, also update `README.md` and `Roadmap.md`.
 - Use clear commit messages describing the change.
+- Update README screenshots when the UI changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,18 @@ Thanks for your interest in improving City_Hive! This project is maintained by m
 
 - Open an issue on GitHub for bugs or feature requests.
 - Include as much detail as possible: browser version, steps to reproduce and screenshots if relevant.
+- For any UI issues, attach a screenshot.
 
 ## Pull Requests
 
 1. Fork the repository and create a feature branch.
-2. Follow our coding style:
+2. Run `black` on Python files and open `docs/index.html` to verify the map works.
+3. Follow our coding style:
    - Python files use [black](https://black.readthedocs.io/) formatting and 4‑space indentation.
    - JavaScript files use 2‑space indentation and should pass `prettier` if installed.
-3. Write clear commit messages and reference related issues when possible.
-4. Update documentation (README, Roadmap, etc.) when your change affects them.
-5. Submit a pull request and wait for review by the maintainers.
+4. Write clear commit messages and reference related issues when possible.
+5. Update documentation (README, Roadmap, screenshots, etc.) when your change affects them.
+6. Submit a pull request and wait for review by the maintainers.
 
 There are currently no automated tests, so please test your changes manually:
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # City_Hive
 
 City_Hive is a lightweight mapping tool for beekeepers, researchers and land stewards in New York City. It lets you log hive locations, swarms, cavity trees and other bee-related sites directly in the browser. No server is required &mdash; markers are stored locally so you can use the map offline on your phone or laptop.
+![Screenshot showing City_Hive interface](docs/screenshot.png)
+
 
 ## Key Features
 
-- **Add and Edit Markers** – place a marker using the `+ Add New Sighting` button and crosshair. Edit or delete any of your markers later.
+- **Add and Edit Markers** – use the crosshair to place markers and edit or delete them later.
 - **Import/Export** – download your markers as JSON and load them again on another device.
+- **Delete All Markers** – remove all your saved markers with one click.
 - **Photo Uploads** – attach a photo (up to 5&nbsp;MB) to a marker. Images are stored in Firebase.
-- **Filtering** – show or hide markers by type (Hive, Swarm, Tree, Structure) via checkboxes.
+- **Filter by Type** – show or hide markers for Hive, Swarm, Tree or Structure.
+- **Help Modal** – quick instructions available from the "?" button.
+- **Distinct Icons** – unique icons identify hives, swarms, trees and structures.
 - **Mobile-Friendly Controls** – gradient-styled buttons with a collapsible menu on small screens, plus a pop‑out legend and a "Locate me" tool for field use.
 - **Local Persistence** – all data is saved in `localStorage` so your notes remain even without a network connection.
 - **Accessible UI** – keyboard-friendly controls with ARIA labels and clear hover states.
@@ -27,6 +32,9 @@ City_Hive is a lightweight mapping tool for beekeepers, researchers and land ste
 - **Add a marker** – click `+ Add New Sighting`, move the map so the crosshair is over the location, then press **Place Here**. Fill out the form and hit **Save**.
 - **Edit/Delete** – click an existing marker and choose **Edit** or **Delete** from the popup.
 - **Import/Export** – use the **Export Markers** and **Import Markers** buttons to transfer your saved points.
+- **Delete All** – use the "Delete All My Markers" button to clear your data.
+- **Filter Markers** – toggle types on or off using the filter button.
+- **Help Button** – tap "?" for quick instructions.
 
 ## FAQ
 
@@ -38,4 +46,4 @@ City_Hive is a lightweight mapping tool for beekeepers, researchers and land ste
 
 Questions or bug reports? Reach out via the NY Bee Club or open an issue on GitHub.
 
-_Last updated: 2025‑06‑01_
+_Last updated: 2025-07-01_

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -2,24 +2,23 @@
 
 ## Completed Milestones
 
-- [x] Editable markers with notes and timestamps
-- [x] Mobile-friendly legend
 - [x] Basic mapping of NYC tree census data
+- [x] Editable markers with notes, photos and timestamps
+- [x] Import/export of user markers as JSON
+- [x] Delete All My Markers option
+- [x] Filtering markers by type
+- [x] Icon set for different marker types
+- [x] Mobile-friendly legend and controls
 - [x] Branded map title and styled default controls
-- [x] Large, touch-friendly controls and help modal
 - [x] Accessibility polish and keyboard navigation
 
 ## In Progress
 
-- [ ] Export user markers as JSON
-- [ ] Import user marker files
-- [ ] Filtering markers by type and date
+- [ ] Date-based filtering of markers
+- [ ] Optional sync/cloud storage across devices
 
 ## Planned / Stretch Goals
 
-- [ ] Icon set for different marker types
-- [ ] Photo upload support (requires storage)
-- [ ] Sync/Cloud storage across devices
 - [ ] Timeline or heatmap visualizations
 - [ ] Admin features for club data sharing
 

--- a/RoadmapSummer.md
+++ b/RoadmapSummer.md
@@ -24,15 +24,15 @@
 
 ## Short-Term Upgrades (Field & Data Features)
 
-- [ ] **Export User Markers**
+- [X] **Export User Markers**
   - Add button to export all markers as CSV or JSON.
   - File should include: type, lat, lng, notes, timestamp, id.
 
-- [ ] **Import User Markers**
+- [X] **Import User Markers**
   - Allow importing previously exported marker files.
   - Merge or replace current data after confirmation.
 
-- [ ] **Filter Markers by Type/Date**
+- [ ] **Filter Markers by Type/Date** (type complete, date TBD)
   - Add UI (checkboxes, dropdowns) to show/hide markers by:
     - Type (Hive, Swarm, Structure, etc.)
     - Date or date range
@@ -41,20 +41,20 @@
 
 ## UI/UX Polish
 
-- [ ] **Large, Touch-Friendly Controls**
+- [X] **Large, Touch-Friendly Controls**
   - Ensure all buttons and controls are easy to tap on mobile devices.
 
-- [ ] **Help/Instructions Modal**
+- [X] **Help/Instructions Modal**
   - Add a “?” or “Help” button with clear usage instructions.
 
-- [ ] **Icons for Marker Types**
+- [X] **Icons for Marker Types**
   - Use distinct icons or shapes for hives, swarms, traps, structures, etc.
 
 ---
 
 ## Optional/Stretch Features (for Later)
 
-- [ ] **Photo Upload for Markers** (optional, requires extra storage)
+- [X] **Photo Upload for Markers** (optional, requires extra storage)
 - [ ] **Sync/Cloud Storage (multi-device)** (requires backend)
 - [ ] **Timeline/Heatmap Visualizations**
 - [ ] **Admin Features/Club Data Sharing**
@@ -65,8 +65,10 @@
 
 ### MVP (Minimum Viable Product)
 
-- [ ] Users can add, edit, and delete markers (with type, notes, timestamp)
-- [ ] Markers can be exported/imported
-- [ ] Legend and controls are mobile-friendly
-- [ ] Data can be filtered for easy viewing
-- [ ] Basic help/instructions available
+- [X] Users can add, edit, and delete markers (with type, notes, timestamp)
+- [X] Markers can be exported/imported
+- [X] Legend and controls are mobile-friendly
+- [X] Data can be filtered for easy viewing
+- [X] Basic help/instructions available
+
+_Last updated: Summer 2025_

--- a/project_notes.md
+++ b/project_notes.md
@@ -1,8 +1,8 @@
-# bee_tree Project Notes (MVP Status, June 2025)
+# City_Hive Project Notes (MVP Status, June 2025)
 
 ## Overview
 
-bee_tree is a browser-based dashboard to map feral honey bee sightings and likely cavity trees in NYC, visualized against city tree census data. Built for the NY Bee Club, researchers, and land stewards.  
+City_Hive is a browser-based dashboard to map feral honey bee sightings and likely cavity trees in NYC, visualized against city tree census data. Built for the NY Bee Club, researchers, and land stewards.
 **Tech stack:** Python (data prep), Leaflet.js (frontend map), no backend (MVP), user annotation with localStorage.
 
 ---


### PR DESCRIPTION
## Summary
- update README with screenshot placeholder, refreshed features, and usage
- mark roadmap milestones as complete and outline next steps
- sync the summer roadmap with the current feature set
- revise contributing guidelines for manual checks and screenshots
- adjust agent instructions and project notes to use the City_Hive name

## Testing
- `black *.py`
- `python -m http.server 8000` and `curl -sI http://localhost:8000/docs/index.html`

------
https://chatgpt.com/codex/tasks/task_e_683fcada5bfc832dae1434b309a7c53f