### PR TITLE
Remove Firebase key and add setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.csv
 *.geojson
+.env

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ City_Hive is a lightweight mapping tool for beekeepers, researchers and land ste
 2. To simply use the map, open `docs/index.html` in a browser. A small web server such as `python -m http.server` is recommended for mobile devices.
 3. Optional: run the scripts in `scripts/` to generate your own GeoJSON files from NYC Open Data.
 
+## API Key Setup
+
+City_Hive uses Firebase Storage for photo uploads. The sample configuration in
+`docs/index.html` contains a placeholder key. To use uploads locally:
+
+1. Create a project in the Google Cloud Console and enable Firebase.
+2. Generate a Web API key and restrict it to your authorized domains.
+3. Replace `YOUR_API_KEY_HERE` in the Firebase config with your key.
+
+Only store this key on your machine. **Do not commit real API keys** to the repository.
+
 ## Usage
 
 - **Open the map** – navigate to `docs/index.html` in your browser.

--- a/docs/index.html
+++ b/docs/index.html
@@ -591,9 +591,10 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-storage-compat.js"></script>
   <script>
+    // Insert your own Firebase API key here for local testing. Do not commit real API keys to the repository.
     // Your web app's Firebase configuration
     const firebaseConfig = {
-      apiKey: "AIzaSyBxuqejpdAdgltobX7tFD_Du6UE9_dTp_c",
+      apiKey: "YOUR_API_KEY_HERE",
       authDomain: "city-hive-90f1e.firebaseapp.com",
       projectId: "city-hive-90f1e",
       storageBucket: "city-hive-90f1e.firebasestorage.app",


### PR DESCRIPTION
## Summary
- scrub the Firebase API key from `index.html`
- ignore local `.env` files
- document how to create and use a personal key in `README`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fd14d06ec832da7f9fb9dddd770ff