### PR TITLE
Center and enlarge logo header for desktop and mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -347,26 +347,33 @@
     #pageHeader {
       display: flex;
       align-items: center;
+      justify-content: center;
       gap: 16px;
-      margin: 10px;
+      margin: 18px 0;
       flex-wrap: wrap;
     }
     #pageHeader img {
-      width: 52px;
-      height: 52px;
+      width: 80px;
+      height: 80px;
       border-radius: 20px;
       box-shadow: 0 2px 8px rgba(110,68,255,0.09);
     }
     #pageHeader .title {
       font-weight: bold;
+      font-size: 2.5rem;
+      letter-spacing: 0.5px;
     }
-    @media (max-width: 500px) {
+    @media (max-width: 600px) {
       #pageHeader img {
-        width: 40px;
-        height: 40px;
+        width: 48px;
+        height: 48px;
       }
       #pageHeader {
         gap: 8px;
+        flex-direction: column;
+      }
+      #pageHeader .title {
+        font-size: 1.4rem;
       }
     }
     .hidden { display: none; }


### PR DESCRIPTION
## Summary
- center the header above the map
- increase the size of the logo and title
- refine responsive sizing for smaller screens

## Testing
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_684048c6a83c832d98e1cdef747ac26e