### PR TITLE
Update docs for Firebase hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 # City_Hive
 ## Project Status
 
-City_Hive is now in open beta. The map and sighting markers work across desktop and mobile, including photo uploads and import/export. Try the demo on [GitHub Pages](https://glitch-bee.github.io/City_Hive/). Bug reports and feedback are welcome.
+City_Hive is now in open beta. The map and sighting markers work across desktop and mobile, including photo uploads and import/export. Try the hosted demo on [Firebase](https://city-hive-90f1e.web.app/). Bug reports and feedback are welcome.
+
+## Live Demo
+
+<https://city-hive-90f1e.web.app/>
+
+City_Hive previously used GitHub Pages for static hosting. We migrated to Firebase Hosting for smoother backend integration and the ability to add real-time features in future updates. The old GitHub Pages site remains available as a legacy mirror.
+Legacy site: <https://glitch-bee.github.io/City_Hive/>
 
 
 City_Hive is a lightweight mapping tool for beekeepers, researchers and land stewards in New York City. It lets you log hive locations, swarms, cavity trees and other bee-related sites directly in the browser. No server is required &mdash; markers are stored locally so you can use the map offline on your phone or laptop.
@@ -29,8 +36,19 @@ City_Hive is a lightweight mapping tool for beekeepers, researchers and land ste
    ```bash
    pip install pandas geopandas requests geojson shapely matplotlib
    ```
-2. To simply use the map, open `docs/index.html` in a browser or visit the demo at https://glitch-bee.github.io/City_Hive/. A small web server such as `python -m http.server` is recommended for mobile devices.
+2. To simply use the map, open `docs/index.html` in a browser or visit the hosted site at <https://city-hive-90f1e.web.app/>. A small web server such as `python -m http.server` is recommended for mobile devices.
 3. Optional: run the scripts in `scripts/` to generate your own GeoJSON files from NYC Open Data.
+
+## Deployment
+
+Prerequisites: [Node.js](https://nodejs.org/), npm and the [Firebase CLI](https://firebase.google.com/docs/cli).
+
+1. `firebase login`
+2. `firebase init hosting` &mdash; select **docs** as the public directory and **do not** overwrite `index.html`.
+3. `firebase serve` to test locally.
+4. `firebase deploy` to publish your site.
+
+The live site is available at <https://city-hive-90f1e.web.app/> once deployed.
 
 ## API Key Setup
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,6 +1,10 @@
 # City_Hive Roadmap
 **Status:** Open Beta
 
+## Hosted Site
+
+<https://city-hive-90f1e.web.app/>
+
 ## Completed Milestones
 
 - [x] Basic mapping of NYC tree census data
@@ -14,8 +18,8 @@
 - [x] Accessibility polish and keyboard navigation
 - [x] Local Firebase config file for API keys
 - [x] Firebase made optional for offline use
-- [x] Public Firebase config committed for GitHub Pages
-- [x] Open beta release on GitHub Pages
+- [x] Public Firebase config committed for static hosting
+- [x] Open beta release (initially on GitHub Pages, now hosted on Firebase)
 
 ## In Progress
 

--- a/RoadmapSummer.md
+++ b/RoadmapSummer.md
@@ -1,6 +1,10 @@
 # City_Hive Beekeeper-Focused Roadmap (Open Beta 2025)
 **Status:** Open Beta
 
+## Hosted Site
+
+<https://city-hive-90f1e.web.app/>
+
 ## Immediate Priorities (Core Usability)
 
 - [X] **Editable Markers**
@@ -71,6 +75,6 @@
 - [X] Legend and controls are mobile-friendly
 - [X] Data can be filtered for easy viewing
 - [X] Basic help/instructions available
-- [X] Open beta release on GitHub Pages
+- [X] Open beta release (originally on GitHub Pages, now hosted on Firebase)
 
 _Last updated: Fall 2025_

--- a/docs/firebaseConfig.js
+++ b/docs/firebaseConfig.js
@@ -1,4 +1,4 @@
-// Public Firebase configuration used by the GitHub Pages build.
+// Public Firebase configuration used by the Firebase Hosting build.
 // The API key below is safe to expose but be sure your
 // Firebase Storage rules restrict writes to authenticated users.
 const firebaseConfig = {

--- a/project_notes.md
+++ b/project_notes.md
@@ -1,5 +1,9 @@
 # City_Hive Project Notes (Beta Status, Fall 2025)
 
+## Hosted Site
+
+<https://city-hive-90f1e.web.app/>
+
 ## Overview
 
 City_Hive is a browser-based dashboard to map feral honey bee sightings and likely cavity trees in NYC, visualized against city tree census data. Built for the NY Bee Club, researchers, and land stewards.
@@ -18,7 +22,7 @@ City_Hive is a browser-based dashboard to map feral honey bee sightings and like
 - **Legend explaining species color codes and user markers**
 - **Performance: MarkerCluster used, no cluster-zoom on click (unclusters only on zoom-in)**
 - **Modern, muted basemap (CartoDB Positron) for visual clarity**
-- **Works from static hosting (e.g. GitHub Pages, no server required)**
+- **Works from static hosting (e.g., Firebase Hosting or GitHub Pages, no server required)**
 
 ---
 


### PR DESCRIPTION
## Summary
- update README with Firebase hosting information and link
- mention the hosted site in roadmap docs and project notes
- mark GitHub Pages as legacy
- note the config comment uses Firebase Hosting

## Testing
- `head -n 5 docs/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68418402a114832db86f4b2f723a4243