### PR TITLE
Fix Firebase script loading

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -622,16 +622,16 @@
   </form>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
-  <script src="main.js" type="module"></script>
-  <script src="markers.js" type="module"></script>
-  <script src="user_markers.js" type="module"></script>
-  <script src="ui.js" type="module"></script>
-  <script src="utils.js" type="module"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-storage-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-storage-compat.js"></script>
   <script src="firebaseConfig.js"></script>
+  <script src="main.js"></script>
+  <script src="markers.js"></script>
+  <script src="user_markers.js"></script>
+  <script src="ui.js"></script>
+  <script src="utils.js"></script>
   <script type="module">
     import { map } from './main.js';
     import { markers } from './markers.js';


### PR DESCRIPTION
## Summary
- reorder Firebase scripts ahead of project modules
- remove `type="module"` from project script tags in `docs/index.html`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68419198cfb0832da9e94d762f1edc1b