### PR TITLE
Remove ES module syntax

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1,7 +1,8 @@
 /**
- * Export the initialized Leaflet map used by other modules.
+ * Initialize the Leaflet map used by other scripts.
  */
-export const map = L.map('map').setView([40.75, -73.95], 11);
+const map = L.map('map').setView([40.75, -73.95], 11);
+window.map = map;
 
 L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
   maxZoom: 19,

--- a/docs/markers.js
+++ b/docs/markers.js
@@ -2,7 +2,6 @@
  * Provides the marker cluster layer for the public tree dataset.
  * Imports the Leaflet map from main.js.
  */
-import { map } from './main.js';
 
 /**
  * Returns a color for the given tree species.
@@ -27,10 +26,11 @@ const getColor = species => {
 };
 
 // Marker cluster group (with cluster-click disabled)
-export const markers = L.markerClusterGroup({
+const markers = L.markerClusterGroup({
   zoomToBoundsOnClick: false,
   spiderfyOnMaxZoom: true
 });
+window.markers = markers;
 
 // Load GeoJSON (filtered citywide trees) with cache-busting query param
 fetch(`full_boro_filtered.geojson?v=${Date.now()}`)

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -1,9 +1,7 @@
 /**
  * UI helpers that interact with the map and user marker logic.
  */
-import { map } from './main.js';
-import { markers } from './markers.js';
-import { addingMode, cancelAddMode, crosshair } from './user_markers.js';
+// expects `map`, `markers`, `addingMode`, `cancelAddMode`, and `crosshair` on the window object
 
 // Disable cluster click-to-zoom (uncluster only on zoom level)
 markers.on('clusterclick', a => {

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -2,4 +2,5 @@
  * Placeholder for shared utilities.
  * Exports a flag indicating if Firebase is available.
  */
-export const firebaseEnabled = typeof firebase !== 'undefined';
+const firebaseEnabled = typeof firebase !== 'undefined';
+window.firebaseEnabled = firebaseEnabled;


### PR DESCRIPTION
## Summary
- remove ES module import/export syntax from docs JS files
- expose shared values on `window`

## Testing
- `black --check .` *(fails: would reformat 7 files)*

------
https://chatgpt.com/codex/tasks/task_e_68419626cc88832d87755048e09ddeaa