### PR TITLE
Fix script tags and Firebase globals

### DIFF
--- a/docs/firebaseConfig.js
+++ b/docs/firebaseConfig.js
@@ -15,6 +15,9 @@ firebase.initializeApp(firebaseConfig);
 const storage = firebase.storage();
 const db = firebase.firestore();
 const auth = firebase.auth();
+window.storage = storage;
+window.db = db;
+window.auth = auth;
 
 auth.onAuthStateChanged(user => {
   if (!user) auth.signInAnonymously().catch(console.error);

--- a/docs/firebaseConfig.local.example.js
+++ b/docs/firebaseConfig.local.example.js
@@ -13,6 +13,9 @@ firebase.initializeApp(firebaseConfig);
 const storage = firebase.storage();
 const db = firebase.firestore();
 const auth = firebase.auth();
+window.storage = storage;
+window.db = db;
+window.auth = auth;
 
 auth.onAuthStateChanged(user => {
   if (!user) auth.signInAnonymously().catch(console.error);

--- a/docs/index.html
+++ b/docs/index.html
@@ -632,9 +632,9 @@
   <script src="user_markers.js"></script>
   <script src="ui.js"></script>
   <script src="utils.js"></script>
- 
+  <script>
     // Optionally, hide legend when clicking outside
-    document.addEventListener('click', function(e) {
+    document.addEventListener('click', function (e) {
       if (legendVisible && !legend.contains(e.target) && !legendToggleBtn.contains(e.target)) {
         legend.style.display = 'none';
         legendVisible = false;
@@ -644,7 +644,7 @@
     // Tree toggle logic
     const treeToggleBtn = document.getElementById('treeToggleBtn');
     let treesVisible = true;
-    treeToggleBtn.onclick = function() {
+    treeToggleBtn.onclick = function () {
       treesVisible = !treesVisible;
       if (treesVisible) {
         window.map.addLayer(window.markers);


### PR DESCRIPTION
## Summary
- wrap stray code in `docs/index.html` in a `<script>` block
- expose Firebase `db`, `auth` and `storage` on `window`
- initialize `firebaseEnabled` earlier and use global Firebase refs
- update user marker logic to use the global Firebase objects

## Testing
- `black --check sorter.py split_js.py scripts/*.py` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_e_68419fc9ac74832dacdc3fba11d87f75