### PR TITLE
Remove Firebase CDN scripts and use modular SDK

### DIFF
--- a/docs/firebaseConfig.js
+++ b/docs/firebaseConfig.js
@@ -1,9 +1,9 @@
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
-import { getStorage } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
-import { getAuth, onAuthStateChanged, signInAnonymously } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+import { initializeApp } from 'firebase/app';
+import { getStorage } from 'firebase/storage';
+import { getFirestore } from 'firebase/firestore';
+import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: "AIzaSyBxuqejpdAdgltobX7tFD_Du6UE9_dTp_c",
   authDomain: "city-hive-90f1e.firebaseapp.com",
   projectId: "city-hive-90f1e",

--- a/docs/firebaseConfig.local.example.js
+++ b/docs/firebaseConfig.local.example.js
@@ -1,10 +1,10 @@
 // Copy this file to firebaseConfig.local.js and fill in your Firebase credentials
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
-import { getStorage } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
-import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
-import { getAuth, onAuthStateChanged, signInAnonymously } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+import { initializeApp } from 'firebase/app';
+import { getStorage } from 'firebase/storage';
+import { getFirestore } from 'firebase/firestore';
+import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: "YOUR_API_KEY_HERE",
   authDomain: "city-hive-90f1e.firebaseapp.com",
   projectId: "city-hive-90f1e",

--- a/docs/index.html
+++ b/docs/index.html
@@ -622,52 +622,6 @@
   </form>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js"></script>
   <script type="module" src="main.js"></script>
-  <script>
-    // Optionally, hide legend when clicking outside
-    document.addEventListener('click', function (e) {
-      if (legendVisible && !legend.contains(e.target) && !legendToggleBtn.contains(e.target)) {
-        legend.style.display = 'none';
-        legendVisible = false;
-        legendToggleBtn.style.background = 'linear-gradient(90deg,#6e44ff 60%,#00b894 100%)';
-      }
-    });
-    // Tree toggle logic
-    const treeToggleBtn = document.getElementById('treeToggleBtn');
-    let treesVisible = true;
-    treeToggleBtn.onclick = function () {
-      treesVisible = !treesVisible;
-      if (treesVisible) {
-        window.map.addLayer(window.markers);
-        treeToggleBtn.style.background = 'linear-gradient(90deg,#00b894 60%,#6e44ff 100%)';
-      } else {
-        window.map.removeLayer(window.markers);
-        treeToggleBtn.style.background = 'linear-gradient(90deg,#bbb 60%,#ccc 100%)';
-      }
-    };
-    const menuBtn = document.getElementById('menuBtn');
-    if (menuBtn) {
-      menuBtn.addEventListener('click', () => {
-        document.body.classList.toggle('menu-open');
-      });
-    }
-    const filterToggleBtn = document.getElementById('filterToggleBtn');
-    const typeFilters = document.getElementById('typeFilters');
-    let filtersVisible = false;
-    if (filterToggleBtn && typeFilters) {
-      filterToggleBtn.addEventListener('click', () => {
-        filtersVisible = !filtersVisible;
-        typeFilters.style.display = filtersVisible ? 'block' : 'none';
-      });
-    }
-    if (window.innerWidth <= 700) {
-      legendVisible = false;
-      legend.style.display = 'none';
-    }
-  </script>
 </body>
 </html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -5,6 +5,6 @@ import { setupUI } from './ui.js';
 import { app, db, storage, auth } from './firebaseConfig.js';
 
 const map = createMap();
-setupPublicMarkers(map);
+const { markers } = setupPublicMarkers(map);
 initUserMarkers(map, { db, storage, auth });
-setupUI(map);
+setupUI(map, markers);

--- a/docs/ui.js
+++ b/docs/ui.js
@@ -1,4 +1,4 @@
-export function setupUI(map) {
+export function setupUI(map, markers) {
   const helpBtn = document.getElementById('helpBtn');
   const helpModal = document.getElementById('helpModal');
   const closeHelp = () => { if (helpModal) helpModal.style.display = 'none'; };
@@ -30,4 +30,60 @@ export function setupUI(map) {
   });
 
   map.on('locationerror', () => { alert('Unable to access your location.'); });
+
+  const legend = document.getElementById('legend');
+  const legendToggleBtn = document.getElementById('legendToggleBtn');
+  let legendVisible = true;
+  if (legend && legendToggleBtn) {
+    legendToggleBtn.addEventListener('click', () => {
+      legendVisible = !legendVisible;
+      legend.style.display = legendVisible ? 'block' : 'none';
+      legendToggleBtn.style.background = legendVisible
+        ? 'linear-gradient(90deg,#00b894 60%,#6e44ff 100%)'
+        : 'linear-gradient(90deg,#6e44ff 60%,#00b894 100%)';
+    });
+    document.addEventListener('click', e => {
+      if (legendVisible && !legend.contains(e.target) && !legendToggleBtn.contains(e.target)) {
+        legend.style.display = 'none';
+        legendVisible = false;
+        legendToggleBtn.style.background = 'linear-gradient(90deg,#6e44ff 60%,#00b894 100%)';
+      }
+    });
+    if (window.innerWidth <= 700) {
+      legendVisible = false;
+      legend.style.display = 'none';
+    }
+  }
+
+  const treeToggleBtn = document.getElementById('treeToggleBtn');
+  let treesVisible = true;
+  if (treeToggleBtn && markers) {
+    treeToggleBtn.onclick = () => {
+      treesVisible = !treesVisible;
+      if (treesVisible) {
+        map.addLayer(markers);
+        treeToggleBtn.style.background = 'linear-gradient(90deg,#00b894 60%,#6e44ff 100%)';
+      } else {
+        map.removeLayer(markers);
+        treeToggleBtn.style.background = 'linear-gradient(90deg,#bbb 60%,#ccc 100%)';
+      }
+    };
+  }
+
+  const menuBtn = document.getElementById('menuBtn');
+  if (menuBtn) {
+    menuBtn.addEventListener('click', () => {
+      document.body.classList.toggle('menu-open');
+    });
+  }
+
+  const filterToggleBtn = document.getElementById('filterToggleBtn');
+  const typeFilters = document.getElementById('typeFilters');
+  let filtersVisible = false;
+  if (filterToggleBtn && typeFilters) {
+    filterToggleBtn.addEventListener('click', () => {
+      filtersVisible = !filtersVisible;
+      typeFilters.style.display = filtersVisible ? 'block' : 'none';
+    });
+  }
 }

--- a/docs/user_markers.js
+++ b/docs/user_markers.js
@@ -8,17 +8,17 @@ import {
   updateDoc,
   deleteDoc,
   onSnapshot
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+} from 'firebase/firestore';
 import {
   ref,
   uploadBytes,
   getDownloadURL,
   deleteObject
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
+} from 'firebase/storage';
 import {
   onAuthStateChanged,
   signInAnonymously
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+} from 'firebase/auth';
 
 export function initUserMarkers(map, { db, storage, auth }) {
 let firebaseEnabled = true;


### PR DESCRIPTION
## Summary
- drop Firebase CDN scripts from `index.html`
- swap Firebase imports for modular npm package usage
- export Firebase config and initialize with it
- move inline UI logic into `ui.js`
- expose markers to UI setup

## Testing
- `black --check .` *(fails: would reformat multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac360b4c832da245de1df9845443