### PR TITLE
Add legacy snapshot of v1 UI

### DIFF
--- a/legacy-index.html
+++ b/legacy-index.html
@@ -1,0 +1,622 @@
+<!-- REFERENCE ONLY – Legacy UI from City_Hive v1, not for production -->
+<head>
+  <title>City_Hive</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css" />
+  <style>
+    body {
+      margin: 0; padding: 0;
+      font-family: 'Segoe UI', 'Roboto', 'Arial Rounded MT Bold', Arial, sans-serif;
+      background: #f7f8fa;
+      color: #222;
+    }
+    #map {
+      height: 90vh; width: 100vw;
+      border-radius: 18px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+      margin-bottom: 12px;
+    }
+    #legend {
+      position: absolute;
+      bottom: 200px;
+      left: 10px;
+      background: rgba(255,255,255,0.97);
+      padding: 16px 18px;
+      border-radius: 16px;
+      font-size: 15px;
+      z-index: 1000;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+      font-family: inherit;
+    }
+    #menuBtn {
+      position: absolute;
+      bottom: 20px;
+      right: 20px;
+      z-index: 1300;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 56px;
+      height: 56px;
+      font-size: 30px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.15);
+      display: none;
+    }
+    #filterToggleBtn {
+      position: absolute;
+      bottom: 150px;
+      left: 10px;
+      z-index: 1100;
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.13);
+      font-size: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      display: none;
+    }
+    #addSightingBtn {
+      position: absolute;
+      top: 120px;
+      right: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+      color: #fff;
+      border: none;
+      border-radius: 16px;
+      padding: 12px 22px;
+      font-size: 18px;
+      font-family: inherit;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s, color 0.2s;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    #exportMarkersBtn {
+      position: absolute;
+      top: 180px;
+      right: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 16px;
+      padding: 10px 20px;
+      font-size: 16px;
+      font-family: inherit;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s, color 0.2s;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    #importMarkersBtn {
+      position: absolute;
+      top: 220px;
+      right: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 16px;
+      padding: 10px 20px;
+      font-size: 16px;
+      font-family: inherit;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s, color 0.2s;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    #deleteAllMarkersBtn {
+      position: absolute;
+      top: 260px;
+      right: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg, #ff6e44 60%, #fdcb6e 100%);
+      color: #222;
+      border: none;
+      border-radius: 16px;
+      padding: 10px 20px;
+      font-size: 16px;
+      font-family: inherit;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    #importMarkersBtn,
+    #exportMarkersBtn,
+    #deleteAllMarkersBtn,
+    #addSightingBtn { min-height: 44px; }
+
+    #typeFilters {
+      position: absolute;
+      top: 320px;
+      right: 10px;
+      z-index: 1200;
+      background: rgba(255,255,255,0.97);
+      padding: 10px 12px;
+      border-radius: 12px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+      font-size: 14px;
+      font-family: inherit;
+    }
+    #typeFilters label {
+      display: block;
+      margin-bottom: 4px;
+    }
+    #addSightingBtn.adding {
+      background: linear-gradient(90deg, #fdcb6e 60%, #ff6e44 100%);
+      color: #222;
+      cursor: crosshair;
+    }
+    #crosshair {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 36px;
+      height: 36px;
+      margin-left: -18px;
+      margin-top: -18px;
+      z-index: 1201;
+      pointer-events: none;
+      display: none;
+      opacity: 0.7;
+    }
+    #placeHereBtn {
+      position: absolute;
+      top: 60px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 1201;
+      display: none;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 14px;
+      padding: 12px 28px;
+      font-size: 18px;
+      font-family: inherit;
+      font-weight: 600;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.14);
+      opacity: 0.97;
+      letter-spacing: 0.5px;
+    }
+    #addTreeForm {
+      position:absolute;
+      top:120px;
+      right:10px;
+      z-index:1300;
+      background:#fff;
+      padding:18px 22px;
+      color:#222;
+      display:none;
+      border-radius:18px;
+      box-shadow:0 2px 16px rgba(0,0,0,0.13);
+      font-family: inherit;
+      min-width: 260px;
+      max-width: 90vw;
+    }
+    #addTreeForm label {
+      font-size: 15px;
+      font-weight: 500;
+      margin-bottom: 6px;
+      display: block;
+      color: #444;
+    }
+    #addTreeForm input[type="text"],
+    #addTreeForm textarea,
+    #addTreeForm select {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid #d1d5db;
+      padding: 8px 10px;
+      margin-bottom: 10px;
+      font-size: 15px;
+      font-family: inherit;
+      background: #f7f8fa;
+      color: #222;
+      box-sizing: border-box;
+      outline: none;
+      transition: border 0.2s;
+    }
+    #addTreeForm input[type="text"]:focus,
+    #addTreeForm textarea:focus,
+    #addTreeForm select:focus {
+      border: 1.5px solid #6e44ff;
+      background: #fff;
+    }
+    #addTreeForm button[type="submit"] {
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+      color: #fff;
+      border: none;
+      border-radius: 10px;
+      padding: 10px 22px;
+      font-size: 16px;
+      font-family: inherit;
+      font-weight: 600;
+      margin-right: 8px;
+      cursor: pointer;
+      box-shadow: 0 1px 6px rgba(0,0,0,0.08);
+      transition: background 0.2s;
+    }
+    #addTreeForm button[type="button"] {
+      background: #eee;
+      color: #444;
+      border: none;
+      border-radius: 10px;
+      padding: 10px 18px;
+      font-size: 16px;
+      font-family: inherit;
+      font-weight: 500;
+      cursor: pointer;
+      box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+      transition: background 0.2s;
+    }
+    #addTreeForm button[type="button"]:hover {
+      background: #f7f8fa;
+    }
+    #addTreeForm button[type="submit"]:hover {
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+    }
+    #legendToggleBtn {
+      position: absolute;
+      bottom: 30px;
+      left: 10px;
+      z-index: 1100;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.13);
+      font-size: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    #helpBtn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      z-index: 1200;
+      background: linear-gradient(90deg,#6e44ff 60%,#00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      font-size: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.13);
+    }
+    #helpModal {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 1500;
+      align-items: center;
+      justify-content: center;
+    }
+    #helpModal .modal-content {
+      background: #fff;
+      padding: 20px;
+      border-radius: 14px;
+      max-width: 320px;
+      width: 90%;
+      color: #222;
+      position: relative;
+    }
+    #helpModal .close-btn {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background: none;
+      border: none;
+      font-size: 24px;
+      cursor: pointer;
+    }
+    #pageHeader {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin: 18px 0;
+      flex-wrap: wrap;
+    }
+    #pageHeader img {
+      width: 80px;
+      height: 80px;
+      border-radius: 20px;
+      box-shadow: 0 2px 8px rgba(110,68,255,0.09);
+    }
+    #pageHeader .title {
+      font-weight: bold;
+      font-size: 2.5rem;
+      letter-spacing: 0.5px;
+    }
+    @media (max-width: 600px) {
+      #pageHeader img {
+        width: 48px;
+        height: 48px;
+      }
+      #pageHeader {
+        gap: 8px;
+        flex-direction: column;
+      }
+      #pageHeader .title {
+        font-size: 1.4rem;
+      }
+    }
+    .hidden { display: none; }
+    .photo-preview {
+      max-width: 100px;
+      max-height: 100px;
+      display: none;
+      border-radius: 8px;
+      margin-bottom: 8px;
+    }
+    #treeToggleBtn,
+    #legendToggleBtn {
+      position: absolute;
+      left: 10px;
+      z-index: 1100;
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.13);
+      font-size: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    #treeToggleBtn { bottom: 90px; }
+    #legendToggleBtn { bottom: 30px; }
+    button:hover {
+      filter: brightness(1.05);
+    }
+    button:active {
+      transform: scale(0.95);
+    }
+    .icon {
+      font-size: 26px;
+      line-height: 1;
+    }
+    #legend strong {
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      color: #6e44ff;
+    }
+    /* Popup styling for Leaflet */
+    .leaflet-popup-content {
+      font-family: inherit;
+      font-size: 15px;
+      color: #222;
+      border-radius: 12px;
+      line-height: 1.5;
+    }
+    .leaflet-popup-content strong {
+      color: #00b894;
+      font-size: 16px;
+      font-weight: 700;
+    }
+    .leaflet-popup-content em {
+      color: #6e44ff;
+      font-style: normal;
+      font-size: 14px;
+    }
+    .leaflet-popup-content small {
+      color: #888;
+      font-size: 12px;
+    }
+    .leaflet-popup-content button {
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 6px 14px;
+      font-size: 14px;
+      font-family: inherit;
+      font-weight: 600;
+      margin: 4px 4px 0 0;
+      cursor: pointer;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+      transition: background 0.2s;
+    }
+    .leaflet-popup-content button:hover {
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+    }
+    .custom-marker-icon {
+      border-radius: 50%;
+      background: none;
+      box-shadow: 0 2px 8px rgba(110,68,255,0.08);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+    }
+    .legend-icon {
+      display: inline-block;
+      vertical-align: middle;
+      width: 20px;
+      height: 20px;
+      margin-right: 4px;
+    }
+    /* Style Leaflet zoom and locate controls */
+    .leaflet-control-zoom a,
+    .leaflet-bar.locate-btn {
+      background: linear-gradient(90deg, #00b894 60%, #6e44ff 100%);
+      color: #fff;
+      border: none;
+      width: 44px;
+      height: 44px;
+      line-height: 44px;
+      font-size: 18px;
+      border-radius: 16px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.10);
+      transition: background 0.2s;
+    }
+    .leaflet-control-zoom-in {
+      border-radius: 16px 16px 0 0 !important;
+    }
+
+    .leaflet-control-zoom-out {
+      border-radius: 0 0 16px 16px !important;
+    }
+    .leaflet-control-zoom {
+      border: none !important;
+      box-shadow: none !important;
+      background: none !important;
+    }
+    .leaflet-control-zoom a {
+      border: none !important;
+      box-shadow: none !important;
+    }
+
+    .leaflet-control-zoom a:hover,
+    .leaflet-bar.locate-btn:hover {
+      background: linear-gradient(90deg, #6e44ff 60%, #00b894 100%);
+    }
+    .leaflet-control-zoom a:active,
+    .leaflet-bar.locate-btn:active {
+      transform: scale(0.95);
+    }
+    @media (max-width: 700px) {
+      #addSightingBtn,
+      #exportMarkersBtn,
+      #importMarkersBtn,
+      #deleteAllMarkersBtn,
+      #typeFilters,
+      #legend { display: none; }
+      body.menu-open #addSightingBtn,
+      body.menu-open #exportMarkersBtn,
+      body.menu-open #importMarkersBtn,
+      body.menu-open #deleteAllMarkersBtn { display: block; }
+      body.menu-open #addSightingBtn { bottom: 80px; right: 20px; top: auto; }
+      body.menu-open #exportMarkersBtn { bottom: 140px; right: 20px; top: auto; }
+      body.menu-open #importMarkersBtn { bottom: 200px; right: 20px; top: auto; }
+      body.menu-open #deleteAllMarkersBtn { bottom: 260px; right: 20px; top: auto; }
+      #menuBtn, #filterToggleBtn { display: flex; }
+    }
+  </style>
+<body>
+  <header id="pageHeader">
+    <img src="cityhive.png" alt="City Hive logo">
+    <span class="title">City_Hive</span>
+  </header>
+  <button id="addSightingBtn" aria-label="Add new sighting" title="Add a new annotation">+ Add New Sighting</button>
+  <button id="exportMarkersBtn" aria-label="Export my markers" title="Download your markers">Export Markers</button>
+  <button id="importMarkersBtn" aria-label="Import marker file" title="Load markers from file">Import Markers</button>
+  <button id="deleteAllMarkersBtn" aria-label="Delete all markers" title="Delete all of my markers">Delete All My Markers</button>
+  <div id="typeFilters">
+    <label><input type="checkbox" data-type="hive" checked> Hive</label>
+    <label><input type="checkbox" data-type="swarm" checked> Swarm</label>
+    <label><input type="checkbox" data-type="tree" checked> Tree</label>
+    <label><input type="checkbox" data-type="structure" checked> Structure</label>
+  </div>
+  <button id="helpBtn" aria-label="Help">?</button>
+  <div id="helpModal" class="hidden">
+    <div class="modal-content">
+      <button class="close-btn" aria-label="Close help">&times;</button>
+      <p>Use "+ Add New Sighting" to place a marker. Import/Export lets you save or load your markers. Use the checkboxes to filter marker types.</p>
+      <p><small>Your markers are stored only in this browser. Uploaded photos are saved to Firebase.</small></p>
+      <p><small><a href="https://github.com" target="_blank" rel="noopener">Feedback / Bug Reports</a></small></p>
+    </div>
+  </div>
+  <div id="crosshair">
+    <svg width="36" height="36">
+      <circle cx="18" cy="18" r="13" stroke="#00b894" stroke-width="2.5" fill="none"/>
+      <line x1="18" y1="6" x2="18" y2="30" stroke="#00b894" stroke-width="2"/>
+      <line x1="6" y1="18" x2="30" y2="18" stroke="#00b894" stroke-width="2"/>
+    </svg>
+  </div>
+  <button id="placeHereBtn" aria-label="Place marker here">Place Here</button>
+  <button id="menuBtn" aria-label="Menu">&#9776;</button>
+  <button id="legendToggleBtn" aria-label="Toggle legend">
+    <span class="icon">&#8505;</span>
+  </button>
+  <button id="treeToggleBtn" aria-label="Toggle tree layer">
+    <span class="icon">🌳</span>
+  </button>
+  <button id="filterToggleBtn" aria-label="Filter">&#128269;</button>
+  <div id="legend" class="hidden">
+    <strong>Legend</strong><br>
+    <span style="color:#ff6600;">&#9679;</span> Norway maple<br>
+    <span style="color:#ffcc00;">&#9679;</span> Sweetgum<br>
+    <span style="color:#00ccff;">&#9679;</span> Callery pear<br>
+    <span style="color:#00ff99;">&#9679;</span> Honeylocust<br>
+    <span style="color:#ff33cc;">&#9679;</span> Red maple<br>
+    <span style="color:#8b5c2a;">&#9679;</span> London planetree<br>
+    <span style="color:#1e90ff;">&#9679;</span> Pin oak<br>
+    <span style="color:#b22222;">&#9679;</span> Red oak<br>
+    <span style="color:#cccccc;">&#9679;</span> Silver maple<br>
+    <span style="color:#004d00;">&#9679;</span> Black locust<br>
+    <span style="color:#009966;">&#9679;</span> American elm<br>
+    <span style="color:#ff3366;">&#9679;</span> Other<br>
+    <span class="legend-icon"><svg width="20" height="20" viewBox="0 0 28 28"><ellipse cx="14" cy="20" rx="8" ry="5" fill="#ffb300" stroke="#b26a00" stroke-width="2"/><ellipse cx="14" cy="15" rx="6" ry="4" fill="#ffd54f" stroke="#b26a00" stroke-width="2"/><ellipse cx="14" cy="11" rx="4" ry="3" fill="#ffe082" stroke="#b26a00" stroke-width="2"/><ellipse cx="14" cy="8" rx="2.5" ry="2" fill="#fffde7" stroke="#b26a00" stroke-width="2"/></svg></span> User Hive<br>
+    <span class="legend-icon"><svg width="20" height="20" viewBox="0 0 28 28"><circle cx="9" cy="15" r="3" fill="#ffb300" stroke="#6e4400" stroke-width="1.2"/><ellipse cx="9" cy="13.5" rx="1.2" ry="2.2" fill="#fff" stroke="#6e4400" stroke-width="0.7"/><circle cx="14" cy="11" r="2.2" fill="#ffb300" stroke="#6e4400" stroke-width="1.2"/><ellipse cx="14" cy="9.7" rx="0.9" ry="1.7" fill="#fff" stroke="#6e4400" stroke-width="0.7"/><circle cx="18" cy="17" r="2.1" fill="#ffb300" stroke="#6e4400" stroke-width="1.2"/><ellipse cx="18" cy="15.7" rx="0.8" ry="1.5" fill="#fff" stroke="#6e4400" stroke-width="0.7"/></svg></span> User Swarm<br>
+    <span class="legend-icon"><svg width="20" height="20" viewBox="0 0 28 28"><ellipse cx="14" cy="14" rx="7" ry="8" fill="#44ff6e" stroke="#1b5e20" stroke-width="2"/><rect x="12" y="18" width="4" height="6" fill="#8d6e63" stroke="#5d4037" stroke-width="1.2"/></svg></span> User Tree<br>
+    <span class="legend-icon"><svg width="20" height="20" viewBox="0 0 28 28"><rect x="7" y="14" width="14" height="8" fill="#ffaa00" stroke="#6e4400" stroke-width="2"/><polygon points="14,6 6,14 22,14" fill="#ffe082" stroke="#6e4400" stroke-width="2"/></svg></span> User Structure
+  </div>
+  <div id="map"></div>
+  <!-- User Tree Input Form -->
+  <form id="addTreeForm">
+    <label>Type:
+      <select id="typeInput">
+        <option value="hive">Hive</option>
+        <option value="swarm">Swarm</option>
+        <option value="tree">Tree</option>
+        <option value="structure">Structure</option>
+      </select>
+    </label><br>
+    <label>Name:<br>
+      <input type="text" id="nameInput" maxlength="40" placeholder="(optional label)">
+    </label><br>
+    <label>Notes:<br>
+      <textarea id="notesInput" rows="2" maxlength="200" placeholder="(optional notes)"></textarea>
+    </label><br>
+    <label>Photo:<br>
+      <input type="file" id="photoInput" accept="image/*" capture="environment">
+    </label><br>
+    <img id="photoPreview" class="photo-preview" alt="Selected photo preview">
+    <label><input type="checkbox" id="showRadiusInput" checked> Show radius</label><br>
+    <input type="hidden" id="latInput">
+    <input type="hidden" id="lngInput">
+    <button type="submit">Save</button>
+    <button type="button" onclick="document.getElementById('addTreeForm').style.display='none'">Cancel</button>
+  </form>
+</body>
+


### PR DESCRIPTION
## Summary
- capture old style and body markup from `docs/index.html`
- provide it in a single `legacy-index.html` file without scripts

## Testing
- `grep -n '<script' -n legacy-index.html`

------
https://chatgpt.com/codex/tasks/task_e_6842d2768b2c832da014686596585efc